### PR TITLE
support for php more php versions and laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     "require": {
         "php": "^8.1||^8.2||^8.3||^8.4",
         "illuminate/contracts": "^9.0 || ^10.0 || ^11.0 ||^12.0",
-        "illuminate/support": "^9.0 || ^10.0 || ^11.0",
-        "illuminate/http": "^9.0 || ^10.0 || ^11.0",
-        "illuminate/routing": "^9.0 || ^10.0 || ^11.0",
-        "illuminate/events": "^9.0 || ^10.0 || ^11.0"
+        "illuminate/support": "^9.0 || ^10.0 || ^11.0 ||^12.0",
+        "illuminate/http": "^9.0 || ^10.0 || ^11.0 ||^12.0",
+        "illuminate/routing": "^9.0 || ^10.0 || ^11.0 ||^12.0",
+        "illuminate/events": "^9.0 || ^10.0 || ^11.0 ||^12.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0",
+        "php": "^8.1||^8.2||^8.3||^8.4",
+        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0 ||^12.0",
         "illuminate/support": "^9.0 || ^10.0 || ^11.0",
         "illuminate/http": "^9.0 || ^10.0 || ^11.0",
         "illuminate/routing": "^9.0 || ^10.0 || ^11.0",
-        "illuminate/events": "^9.0 || ^10.0 || ^11.0"
+        "illuminate/events": "^9.0 || ^10.0 || ^11.0",
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/support": "^9.0 || ^10.0 || ^11.0",
         "illuminate/http": "^9.0 || ^10.0 || ^11.0",
         "illuminate/routing": "^9.0 || ^10.0 || ^11.0",
-        "illuminate/events": "^9.0 || ^10.0 || ^11.0",
+        "illuminate/events": "^9.0 || ^10.0 || ^11.0"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
I updated the composer.json file to support php versions 8.2, 8.3, 8.4 and 8.5.  I also added support for laravel 12.

 "require": {
        "php": "^8.1||^8.2||^8.3||^8.4",
        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0 ||^12.0",
        "illuminate/support": "^9.0 || ^10.0 || ^11.0 ||^12.0",
        "illuminate/http": "^9.0 || ^10.0 || ^11.0 ||^12.0",
        "illuminate/routing": "^9.0 || ^10.0 || ^11.0 ||^12.0",
        "illuminate/events": "^9.0 || ^10.0 || ^11.0 ||^12.0"
    },